### PR TITLE
chore(deps): upgrade worker base image

### DIFF
--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -367,7 +367,7 @@ jobs:
 
       - name: Set up Node.js for Copilot CLI
         if: steps.copilot-availability.outputs.available == 'true'
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v6
         timeout-minutes: 3
         with:
           node-version: "22"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a pinned udx-worker release
-FROM usabilitydynamics/udx-worker:0.46.0
+FROM usabilitydynamics/udx-worker:0.47.0
 
 # Add metadata labels
 LABEL version="0.32.0"


### PR DESCRIPTION
## Summary

- Upgrade the worker-nodejs parent image from `usabilitydynamics/udx-worker:0.46.0` to `usabilitydynamics/udx-worker:0.47.0`.
- Repair the dependency updater workflow by changing the Copilot setup step from `actions/setup-node@v7` to `actions/setup-node@v6`.

## Scope

- Changed: `Dockerfile` base image pin and the updater workflow action pin.
- Not changed: Node.js remains `24.18.0`; `xz-utils` remains `5.8.1-1build2`.

## Validation

- Verified `usabilitydynamics/udx-worker:0.47.0` has a multi-arch Docker manifest.
- Verified `actions/setup-node@v6` exists and `actions/setup-node@v7` does not exist.
- Previous updater failure stopped at action resolution for `actions/setup-node@v7`: https://github.com/udx/worker-nodejs/actions/runs/29117383679

## Follow-up

- After this PR merges and releases worker-nodejs, upgrade worker-engine to the new worker-nodejs tag.
