### PR TITLE
fix(ci): run dependency probe apt step as root

### DIFF
--- a/.github/workflows/docker-dependency-updater.yml
+++ b/.github/workflows/docker-dependency-updater.yml
@@ -197,10 +197,12 @@ jobs:
           {
             echo
             echo "# Dependency probe keeps apt packages installed for dpkg-query."
+            echo "USER root"
             echo "RUN set -ex && \\"
             echo "    apt-get update && \\"
             echo "    apt-get install -y --no-install-recommends ${apt_packages[*]} && \\"
             echo "    rm -rf /var/lib/apt/lists/*"
+            echo 'USER "${USER}"'
           } >> "${PROBE_DOCKERFILE}"
 
           docker build --pull --no-cache -f "${PROBE_DOCKERFILE}" \


### PR DESCRIPTION
## The problem 

https://github.com/udx/worker-nodejs/actions/runs/30517941072/job/90791862424

<img width="1707" height="623" alt="image" src="https://github.com/user-attachments/assets/00a782ab-2f31-4c69-9ad3-1d8148cb8bc6" />

## Summary

- Run the generated dependency probe package-install layer as root.
- Restore the image runtime user before probing installed package versions.

## Validation

- Ruby YAML parse
- `git diff --check`