### PR TITLE
chore(deps): docker dependency upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a pinned udx-worker release
-FROM usabilitydynamics/udx-worker:0.47.0
+FROM usabilitydynamics/udx-worker:0.49.0
 
 # Add metadata labels
 LABEL version="0.32.0"


### PR DESCRIPTION
## Summary

Updates worker-nodejs Dockerfile dependency pins.

## Evidence

- Probe report artifact: `docker-dependency-report.json`
- Copilot CLI: updated non-apt dependencies
- Copilot session artifact: `copilot-docker-dependency-session.md`
## Diff

```diff
diff --git a/Dockerfile b/Dockerfile
index 0b95004..5c4b8bc 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a pinned udx-worker release
-FROM usabilitydynamics/udx-worker:0.47.0
+FROM usabilitydynamics/udx-worker:0.49.0
 
 # Add metadata labels
 LABEL version="0.32.0"
```
